### PR TITLE
Allow 'copilot' prefix in branch naming convention

### DIFF
--- a/.github/workflows/enforce-branch-naming.yml
+++ b/.github/workflows/enforce-branch-naming.yml
@@ -12,7 +12,7 @@ jobs:
         run: |
           BRANCH="${GITHUB_HEAD_REF}"
           echo "Checking branch: $BRANCH"
-          if [[ ! "$BRANCH" =~ ^(feature|hotfix|bugfix)/ ]]; then
+          if [[ ! "$BRANCH" =~ ^(feature|hotfix|bugfix|copilot)/ ]]; then
             echo "❌ Invalid branch name: $BRANCH"
             echo "Branch name must start with feature/, hotfix/ or bugfix/"
             exit 1


### PR DESCRIPTION
Added 'copilot' as a valid prefix for branch names.